### PR TITLE
feat: add block participants updates

### DIFF
--- a/src/pages/rejestracja/[participationSlug]/index.tsx
+++ b/src/pages/rejestracja/[participationSlug]/index.tsx
@@ -68,8 +68,12 @@ export default function Building({
 
       return blocks.data;
     },
-  });
-
+    refetchOnWindowFocus: true, 
+    refetchOnReconnect: true,  
+    refetchOnMount: true,
+    refetchInterval: 1000
+  },
+);
   const currentBlocks = allBlocksQuery.data
     ?.filter((block) => block.parentBlockId === blockId)
     .slice()

--- a/src/pages/rejestracja/[participationSlug]/index.tsx
+++ b/src/pages/rejestracja/[participationSlug]/index.tsx
@@ -68,9 +68,6 @@ export default function Building({
 
       return blocks.data;
     },
-    refetchOnWindowFocus: true,
-    refetchOnReconnect: true,
-    refetchOnMount: true,
     refetchInterval: 1000,
   });
   const currentBlocks = allBlocksQuery.data

--- a/src/pages/rejestracja/[participationSlug]/index.tsx
+++ b/src/pages/rejestracja/[participationSlug]/index.tsx
@@ -68,12 +68,11 @@ export default function Building({
 
       return blocks.data;
     },
-    refetchOnWindowFocus: true, 
-    refetchOnReconnect: true,  
+    refetchOnWindowFocus: true,
+    refetchOnReconnect: true,
     refetchOnMount: true,
-    refetchInterval: 1000
-  },
-);
+    refetchInterval: 1000,
+  });
   const currentBlocks = allBlocksQuery.data
     ?.filter((block) => block.parentBlockId === blockId)
     .slice()


### PR DESCRIPTION
## Intro
The participant list in blocks did not refresh after a participant registered. After conducting an in-depth analysis, I discovered that participant data in blocks is not refreshed at all. This is a critical functionality since users need real-time updates to confirm whether someone else has already taken their place in real life.


## Changes
I've added all the prefetch parameters I could change. By default, places are refreshed every second using a pooling methodology. This also happens after the window focus changes, after reconnecting, and on mounting. This ensures a smooth experience.

## Future development
I also noticed that the whole event (meaning configuration I guess) is also refreshed every second. This produces quite a lot of requests and we should ask ourselves how we can optimize it. 